### PR TITLE
Update build icons to `harp-orm/harp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Harp ORM
 
-[![Build Status](https://travis-ci.org/harp-orm/db.svg?branch=master)](https://travis-ci.org/harp-orm/db)
-[![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/harp-orm/db/badges/quality-score.png?s=57a2e2c70f39e76cd55d7d6d7938a56404deb468)](https://scrutinizer-ci.com/g/harp-orm/db/)
-[![Code Coverage](https://scrutinizer-ci.com/g/harp-orm/db/badges/coverage.png?s=ffc98c29ef43ccddf14b2df890f230a9c1d99e18)](https://scrutinizer-ci.com/g/harp-orm/db/)
-[![Latest Stable Version](https://poser.pugx.org/openbuildings/luna/v/stable.svg)](https://packagist.org/packages/openbuildings/luna)
+[![Build Status](https://travis-ci.org/harp-orm/harp.svg?branch=master)](https://travis-ci.org/harp-orm/harp)
+[![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/harp-orm/harp/badges/quality-score.png?s=57a2e2c70f39e76cd55d7d6d7938a56404deb468)](https://scrutinizer-ci.com/g/harp-orm/harp/)
+[![Code Coverage](https://scrutinizer-ci.com/g/harp-orm/harp/badges/coverage.png?s=ffc98c29ef43ccddf14b2df890f230a9c1d99e18)](https://scrutinizer-ci.com/g/harp-orm/harp/)
+[![Latest Stable Version](https://poser.pugx.org/openbuildings/harp/v/stable.svg)](https://packagist.org/packages/harp-orm/harp)
 
 ## License
 


### PR DESCRIPTION
I've unified the build icons to always use `harp-orm/harp` instead of `openbuildings/luna` and `harp-orm/db`.

However the project in Scrutinizer CI (other services may be affected as well) needs to be re-added. They obviously don't have very good support for renaming GitHub repositories.
