### PR TITLE
getForeignKey function doesn't work correct

### DIFF
--- a/src/Rel/BelongsTo.php
+++ b/src/Rel/BelongsTo.php
@@ -53,7 +53,7 @@ class BelongsTo extends AbstractRelOne implements UpdateOneInterface, FindModels
      */
     public function getForeignKey()
     {
-        return $this->getConfig()->getPrimaryKey();
+        return $this->getRepo()->getConfig()->getPrimaryKey();
     }
 
     /**


### PR DESCRIPTION
BUG FIX : Get the primaryKey from the foreign model instead of the primaryKey from current model 

Only applies to BelongsTo relation
